### PR TITLE
Updated qstring.py to Python3

### DIFF
--- a/qstring.py
+++ b/qstring.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import lldb
 
 def utf16string_summary(value, *rest):
@@ -16,7 +18,7 @@ def utf16string_summary(value, *rest):
     return '"%s"' % (bytes.decode('utf-16').encode('utf-8'))
 
 def __lldb_init_module(debugger, *rest):
-    print "registering QString"
+    print("registering QString")
     summary = lldb.SBTypeSummary.CreateWithFunctionName("qstring.utf16string_summary")
     summary.SetOptions(lldb.eTypeOptionHideChildren)
     debugger.GetDefaultCategory().AddTypeSummary( lldb.SBTypeNameSpecifier("QString", False), summary )


### PR DESCRIPTION
Python3 syntax demands `print` arguments passed within regular function parens.